### PR TITLE
An empty response with an indicated 0 total is treated as an empty array

### DIFF
--- a/addon/serializers/application.js
+++ b/addon/serializers/application.js
@@ -43,7 +43,17 @@ export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
       hash = {};
 
     if (isEmpty(get(payload, 'entry'))) {
-      resourceArray = [ payload ];
+
+      // This is a query where nothing was returned.
+      // Create an empty array in the hash so that subsequent parsing doesn't complain that there are 0 expected objects
+      if (payload.total === 0) {
+        hash[Ember.String.pluralize(primaryModelClass.modelName)] = [];
+        return this._super(store, primaryModelClass, hash, id, requestType);
+      } else {
+        resourceArray = [ payload ];
+      }
+
+
     } else {
       resourceArray = get(payload, 'entry').mapBy('resource');
     }


### PR DESCRIPTION
This addresses empty .query responses generating an error because they are being interpreted as a single record instead of an array as .query expects, issue #1.