### PR TITLE
Query Response Metadata

### DIFF
--- a/addon/serializers/application.js
+++ b/addon/serializers/application.js
@@ -40,7 +40,9 @@ export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
 
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
     let resourceArray = null,
-      hash = {};
+      hash = {
+        'meta': {},
+      };
 
     if (isEmpty(get(payload, 'entry'))) {
 
@@ -74,6 +76,16 @@ export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
 
       hash[type].push(resource);
     });
+
+    if (payload.link) {
+      let meta = {};
+      payload.link.forEach(link => { meta[link.relation] = link.url; });
+      hash['meta']['pagination'] = meta;
+    }
+
+    if (payload.total) {
+      hash['meta']['total'] = payload.total;
+    }
 
     return this._super(store, primaryModelClass, hash, id, requestType);
   },


### PR DESCRIPTION
Query response metadata is not provided by the serializer. This change aggregates `total` and `link` values into `meta` for use in routes.